### PR TITLE
fix(pangu): keep sort order and filters on portfolio during navigation

### DIFF
--- a/apps/pangu/src/app/pages/dashboard/dashboard.page.html
+++ b/apps/pangu/src/app/pages/dashboard/dashboard.page.html
@@ -264,7 +264,52 @@
         [type]="ChartType.DOUGHNUT"
         [data]="portfolioCompositionChartData"
         [options]="portfolioCompositionChartOptions"
+        [hidden]="isPortfolioCompositionChartLoading || isPortfolioCompositionChartNoData"
       ></canvas>
+      @if (isPortfolioCompositionChartLoading) {
+      <div class="flex h-full flex-1 items-center justify-center" role="status">
+        <svg
+          aria-hidden="true"
+          class="h-8 w-8 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600"
+          viewBox="0 0 100 101"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+            fill="currentColor"
+          />
+          <path
+            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+            fill="currentFill"
+          />
+        </svg>
+        <span class="sr-only">Loading...</span>
+      </div>
+      } @if (isPortfolioCompositionChartNoData) {
+      <div
+        class="flex h-full flex-col items-center justify-center text-gray-500 dark:text-gray-400"
+        role="status"
+      >
+        <svg
+          class="mx-auto mb-4 h-12 w-12"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 20 20"
+        >
+          <path
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M10 11V6m0 8h.01M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+
+        <span>No Data</span>
+      </div>
+      }
     </div>
   </div>
   } @else {

--- a/apps/pangu/src/app/pages/dashboard/dashboard.page.ts
+++ b/apps/pangu/src/app/pages/dashboard/dashboard.page.ts
@@ -78,6 +78,9 @@ export class DashboardPage {
   public isPortfolioPerformanceChartInFullscreen = false;
   public isPortfolioPerformanceChartNoData = false;
 
+  public isPortfolioCompositionChartLoading = true;
+  public isPortfolioCompositionChartNoData = false;
+
   public portfolioCompositionChartData: DoughnutChartData<
     ChartType.DOUGHNUT,
     number[],
@@ -153,9 +156,6 @@ export class DashboardPage {
         untilDestroyed(this),
       )
       .subscribe((data) => {
-        this.isPortfolioPerformanceChartLoading = false;
-        this.isPortfolioPerformanceChartNoData = data.length === 0;
-
         if (data.length > 0) {
           this.isPortfolioPerformanceChartNoData = false;
 
@@ -242,16 +242,27 @@ export class DashboardPage {
 
     combineLatest([
       dashboardService.getPortfolioComposition(),
-      settingsService.settings$.pipe(distinctUntilKeyChanged('colorScheme')),
+      settingsService.settings$.pipe(
+        distinctUntilKeyChanged('colorScheme'),
+        tap(() => (this.isPortfolioCompositionChartLoading = true)),
+      ),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([{ weight, stocks }, { colorScheme }]) => {
-        const colors = ChartUtils.generateChartColors(
-          stocks.length,
-          colorScheme,
-        );
+        if (stocks.length > 0) {
+          this.isPortfolioCompositionChartNoData = false;
 
-        this.updatePortfolioCompositionChart(weight, stocks, colors);
+          const colors = ChartUtils.generateChartColors(
+            stocks.length,
+            colorScheme,
+          );
+
+          this.updatePortfolioCompositionChart(weight, stocks, colors);
+        } else {
+          this.isPortfolioCompositionChartNoData = true;
+        }
+
+        this.isPortfolioCompositionChartLoading = false;
       });
   }
 

--- a/apps/pangu/src/app/pages/portfolio/portfolio.page.html
+++ b/apps/pangu/src/app/pages/portfolio/portfolio.page.html
@@ -367,6 +367,27 @@
       </div>
 
       <div class="flex space-x-3">
+        <!-- Clear Button -->
+        <button
+          (click)="clearAllFilters()"
+          class="hover:text-primary-700 flex items-center justify-center rounded-md border border-gray-200 bg-white px-2 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-200 focus:outline-hidden md:w-auto dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
+          type="button"
+          title="Clear filters"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+
         <!-- Buy Button -->
         <button
           (click)="openAddTransactionDrawer(TransactionType.BUY)"

--- a/apps/pangu/src/app/pages/portfolio/portfolio.page.spec.ts
+++ b/apps/pangu/src/app/pages/portfolio/portfolio.page.spec.ts
@@ -1,5 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { PortfolioPage } from './portfolio.page';
 
@@ -10,7 +11,7 @@ describe('PortfolioPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PortfolioPage],
-      providers: [provideHttpClient()],
+      providers: [provideHttpClient(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PortfolioPage);

--- a/apps/pangu/src/app/pages/portfolio/portfolio.page.ts
+++ b/apps/pangu/src/app/pages/portfolio/portfolio.page.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dropdown } from 'flowbite';
 import {
   BehaviorSubject,
@@ -82,6 +82,8 @@ export class PortfolioPage implements AfterViewInit {
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly storageService = inject(StorageService);
   private readonly marketService = inject(MarketService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   private readonly transactionDateInputRef = viewChild<ElementRef>(
     'transactionDateInput',
@@ -194,6 +196,8 @@ export class PortfolioPage implements AfterViewInit {
       })),
       share(),
     );
+
+    this.restoreFromQueryParams();
 
     this.stockSearchResults$ = toObservable(this.name).pipe(
       debounceTime(500), // TODO: Review the time
@@ -404,7 +408,7 @@ export class PortfolioPage implements AfterViewInit {
 
   public filterPortfolio(filter: PortfolioFilter): void {
     this.portfolioFilter$.next(filter);
-
+    this.syncQueryParams();
     if (this.filterDropdown) {
       this.filterDropdown.hide();
     }
@@ -412,7 +416,7 @@ export class PortfolioPage implements AfterViewInit {
 
   public clearPortfolioFilters(): void {
     this.portfolioFilter$.next(PortfolioFilter.NONE);
-
+    this.syncQueryParams();
     if (this.filterDropdown) {
       this.filterDropdown.hide();
     }
@@ -423,10 +427,76 @@ export class PortfolioPage implements AfterViewInit {
     order: PortfolioSortOrder,
   ): void {
     this.portfolioSort$.next([type, order]);
+    this.syncQueryParams();
+    if (this.sortDropdown) {
+      this.sortDropdown.hide();
+    }
+  }
+
+  public clearAllFilters(): void {
+    this.portfolioFilter$.next(PortfolioFilter.NONE);
+    this.portfolioSort$.next([
+      PortfolioSortType.DAY_PROFIT_LOSS,
+      PortfolioSortOrder.DSC,
+    ]);
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: {},
+      replaceUrl: true,
+    });
 
     if (this.sortDropdown) {
       this.sortDropdown.hide();
     }
+    if (this.filterDropdown) {
+      this.filterDropdown.hide();
+    }
+  }
+
+  private restoreFromQueryParams(): void {
+    const params = this.route.snapshot.queryParamMap;
+    const sortType = params.get('sortType') as PortfolioSortType | null;
+    const sortOrder = params.get('sortOrder') as PortfolioSortOrder | null;
+
+    if (
+      sortType &&
+      sortOrder &&
+      Object.values(PortfolioSortType).includes(sortType) &&
+      Object.values(PortfolioSortOrder).includes(sortOrder)
+    ) {
+      this.portfolioSort$.next([sortType, sortOrder]);
+    }
+
+    const filter = params.get('filter') as PortfolioFilter | null;
+
+    if (filter && Object.values(PortfolioFilter).includes(filter)) {
+      this.portfolioFilter$.next(filter);
+    }
+  }
+
+  private syncQueryParams(): void {
+    const [sortType, sortOrder] = this.portfolioSort$.getValue();
+    const filter = this.portfolioFilter$.getValue();
+    const queryParams: Record<string, string> = {};
+
+    if (
+      sortType !== PortfolioSortType.DAY_PROFIT_LOSS ||
+      sortOrder !== PortfolioSortOrder.DSC
+    ) {
+      queryParams['sortType'] = sortType;
+      queryParams['sortOrder'] = sortOrder;
+    }
+
+    if (filter !== PortfolioFilter.NONE) {
+      queryParams['filter'] = filter;
+    }
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      replaceUrl: true,
+    });
   }
 
   private showTransactionFormError(message: string): void {


### PR DESCRIPTION
Thank you for taking the time to submit this pull request!

fix(pangu): keep sort order and filters on portfolio during navigation
fix(pangu): show loading and no data states in portfolio composition chart

## Affected App(s)

- [x] Pangu
- [ ] Vatti
- [ ] Palan

## Change Type

> _Please try to limit your pull request to one type, submit multiple pull requests if needed._

What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Testing related changes
- [ ] Build/CI related changes
- [ ] Other (_please describe_):

## Current Behavior

> _Description of the current behavior that you are modifying._

### Related Issues

> _Link to relevant issues (if applicable)._

**Issue Number**:

## New Behavior

> _Description of the new behavior that you are introducing._

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/hyperweavers/nidhi/blob/main/CONTRIBUTING.md) to this project.
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added/updated tests to cover my changes.

## Breaking Change

Does this PR introduce a change that would cause existing functionality to not work as expected?

- [ ] Yes
- [x] No
